### PR TITLE
added default value with JSDoc

### DIFF
--- a/src/confetti/index.tsx
+++ b/src/confetti/index.tsx
@@ -12,12 +12,33 @@ const DURATION = 2200;
 const COLORS = ['#FFC700', '#FF0000', '#2E3191', '#41BBC7'];
 
 export interface ConfettiProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'ref'> {
+  /**
+    * @default 100
+    */
   particleCount?: number;
+  /**
+    * @default 2200
+    */
   duration?: number;
+  /**
+    * @default ['#FFC700', '#FF0000', '#2E3191', '#41BBC7']
+    */
   colors?: string[];
+  /**
+    * @default 12
+    */
   particleSize?: number;
+  /**
+    * @default 0.5
+    */
   force?: number;
+  /**
+    * @default "120vh"
+    */
   height?: number | string;
+  /**
+    * @default 1000
+    */
   width?: number;
   zIndex?: number;
   onComplete?: () => void;


### PR DESCRIPTION
It would be handy if I could immediately see the default value when writing a property. I'm not sure if the JSDoc comments will remain after the build, but I think you can fix it!