### PR TITLE
feat: add images and repeats as options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-confetti-explosion",
-  "version": "2.1.2",
+  "name": "react-confetti-image-explosion",
+  "version": "0.0.1",
   "author": "Ethan Herr <herrethan@gmail.com>",
   "description": "A lightweight css-animation based confetti exploder for React",
   "license": "MIT",

--- a/src/confetti/index.tsx
+++ b/src/confetti/index.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import range from 'lodash/range';
 import { createPortal } from 'react-dom';
-import useStyles, { IParticle, IStyleClasses } from './styles';
+import useStyles, {IParticle, IStyleClasses } from './styles';
 
 const FORCE = 0.5; // 0-1 roughly the vertical force at which particles initially explode
 const SIZE = 12; // max height for particle rectangles, diameter for particle circles
@@ -9,17 +9,18 @@ const HEIGHT = '120vh'; // distance particles will fall from initial explosion p
 const WIDTH = 1000; // horizontal spread of particles in pixels
 const PARTICLE_COUNT = 100;
 const DURATION = 2200;
-const COLORS = ['#FFC700', '#FF0000', '#2E3191', '#41BBC7'];
 
 export interface ConfettiProps extends Omit<React.HTMLAttributes<HTMLDivElement>, 'ref'> {
   particleCount?: number;
   duration?: number;
   colors?: string[];
+  images?: string[];
   particleSize?: number;
   force?: number;
   height?: number | string;
   width?: number;
   zIndex?: number;
+  repeats?: number;
   onComplete?: () => void;
 }
 
@@ -27,6 +28,16 @@ const createParticles = (count: number, colors: string[]): IParticle[] => {
   const increment = 360 / count;
   return range(count).map(index => ({
     color: colors[index % colors.length],
+    image: '',
+    degree: increment * index,
+  }));
+};
+
+const createImageParticles = (count: number, images: string[]): IParticle[] => {
+  const increment = 360 / count;
+  return range(count).map(index => ({
+    image: images[index % images.length],
+    color: '',
     degree: increment * index,
   }));
 };
@@ -34,20 +45,24 @@ const createParticles = (count: number, colors: string[]): IParticle[] => {
 function ConfettiExplosion({
   particleCount = PARTICLE_COUNT,
   duration = DURATION,
-  colors = COLORS,
+  colors = [],
+  images = [],
   particleSize = SIZE,
   force = FORCE,
   height = HEIGHT,
   width = WIDTH,
   zIndex,
+  repeats = 1,
   onComplete,
   ...props
 }: ConfettiProps) {
   const [origin, setOrigin] = React.useState<{ top: number; left: number }>();
   const particles = createParticles(particleCount, colors);
+  const imageParticles = createImageParticles(particleCount, images);
   const classes: IStyleClasses = useStyles({
-    particles,
+    particles: images.length ? imageParticles : particles,
     duration,
+    repeats,
     particleSize,
     force,
     width,

--- a/src/confetti/styles.ts
+++ b/src/confetti/styles.ts
@@ -17,12 +17,14 @@ export interface IStyleClasses {
 
 export interface IParticle {
   color: string; // color of particle
+  image: string; // image of particle 
   degree: number; // vector direction, between 0-360 (0 being straight up ↑)
 }
 
 interface IParticlesProps {
-  particles: IParticle[];
+  particles: IParticle[]; // particles to explode
   duration: number;
+  repeats: number;
   particleSize: number;
   force: number;
   height: number | string;
@@ -67,12 +69,13 @@ const confettiKeyframes = (degrees: number[], height: number | string, width: nu
   };
 };
 
-const confettoStyle = (particle: IParticle, duration: number, force: number, size: number, i: number) => {
+const confettoStyle = (particle: IParticle, duration: number, repeats: number, force: number, size: number, i: number) => {
   const rotation = Math.round(Math.random() * (ROTATION_SPEED_MAX - ROTATION_SPEED_MIN) + ROTATION_SPEED_MIN);
   const rotationIndex = Math.round(Math.random() * (rotationTransforms.length - 1));
   const durationChaos = duration - Math.round(Math.random() * 1000);
   const shouldBeCrazy = Math.random() < CRAZY_PARTICLES_FREQUENCY;
   const isCircle = shouldBeCircle(rotationIndex);
+  const isImage = particle.image !== undefined;
 
   // x-axis disturbance, roughly the distance the particle will initially deviate from its target
   const x1 = shouldBeCrazy ? round(Math.random() * CRAZY_PARTICLE_CRAZINESS, 2) : 0;
@@ -94,11 +97,14 @@ const confettoStyle = (particle: IParticle, duration: number, force: number, siz
     [`&#confetti-particle-${i}`]: {
       animation: `$x-axis-${i} ${durationChaos}ms forwards cubic-bezier(${x1}, ${x2}, ${x3}, ${x4})`,
       '& > div': {
-        width: isCircle ? size : Math.round(Math.random() * 4) + size / 2,
-        height: isCircle ? size : Math.round(Math.random() * 2) + size,
+        width: isCircle || isImage ? size : Math.round(Math.random() * 4) + size / 2,
+        height: isCircle || isImage ? size : Math.round(Math.random() * 2) + size,
         animation: `$y-axis ${durationChaos}ms forwards cubic-bezier(${y1}, ${y2}, ${y3}, ${y4})`,
+        animationIterationCount: repeats,
         '&:after': {
-          backgroundColor: particle.color,
+          backgroundColor: particle.color ? particle.color : 'unset',
+          backgroundImage: particle.image ? `url(${particle.image})` : 'unset',
+          backgroundSize: isImage ? "cover" : "unset",
           animation: `$rotation-${rotationIndex} ${rotation}ms infinite linear`,
           ...(isCircle ? { borderRadius: '50%' } : {}),
         },
@@ -107,11 +113,11 @@ const confettoStyle = (particle: IParticle, duration: number, force: number, siz
   };
 };
 
-const useStyles = ({ particles, duration, height, width, force, particleSize }: IParticlesProps) => {
+const useStyles = ({ particles, duration, repeats, height, width, force, particleSize }: IParticlesProps) => {
   const confettiStyles = particles.reduce(
     (acc, particle, i) => ({
       ...acc,
-      ...confettoStyle(particle, duration, force, particleSize, i),
+      ...confettoStyle(particle, duration, repeats, force, particleSize, i),
     }),
     {}
   );


### PR DESCRIPTION
Allows back ground images instead of colours and a value used for animation-iteration-count, although it looks weird if gt 1