### PR TITLE
Allow default export

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export { ConfettiExplosion } from './confetti';
+export { ConfettiExplosion as default } from './confetti';
 export type { ConfettiProps } from './confetti';


### PR DESCRIPTION
# Description

Currently, the latest release of the library (v3) no longer allows a default export. The following import no longer works for v3.

```js
import ConfettiExplosion from 'react-confetti-explosion';
```

It is necessary to import the library with a named import now:

```js
import { ConfettiExplosion } from 'react-confetti-explosion';
```

Not sure if that was intentional or not but if so, the documentation needs to be updated (as the current example in the README is invalid) and this breaking change should be highlighted.

If not intentional, this PR serves to add default export functionality while maintaining backward compatibility with existing named exports. 